### PR TITLE
Text view hight calculation with placeholder text

### DIFF
--- a/AutoLayoutTextViews.xcodeproj/project.pbxproj
+++ b/AutoLayoutTextViews.xcodeproj/project.pbxproj
@@ -1,1203 +1,590 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>0154CB6408E142EDBF9F6F69</key>
-		<dict>
-			<key>fileRef</key>
-			<string>487F164A8F7D4EEEA6DBA088</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>015C12BBC346E6EC48E4175F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-AutoLayoutTextViewsTests.release.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-AutoLayoutTextViewsTests/Pods-AutoLayoutTextViewsTests.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>3D0B36F7E6184547AF32BA2F</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods-AutoLayoutTextViewsTests/Pods-AutoLayoutTextViewsTests-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>42613CED1A09AFCB00CAEDBB</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Test_ALKeyboardAvoidingTextView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>42613CEE1A09AFCB00CAEDBB</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Test_ALKeyboardAvoidingTextView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>42613CEF1A09AFCB00CAEDBB</key>
-		<dict>
-			<key>fileRef</key>
-			<string>42613CEE1A09AFCB00CAEDBB</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>446084F7194282310093A6FA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ALAutoResizingTextView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>446084F8194282310093A6FA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ALAutoResizingTextView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>446084F9194282310093A6FA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>446084F8194282310093A6FA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>446084FE194283600093A6FA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ALPlaceholderTextView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>446084FF194283600093A6FA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ALPlaceholderTextView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>44608500194283600093A6FA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>446084FF194283600093A6FA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>44608502194283AC0093A6FA</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>446084F7194282310093A6FA</string>
-				<string>446084F8194282310093A6FA</string>
-				<string>44FC5CF01946581C004812F4</string>
-				<string>44FC5CF11946581C004812F4</string>
-				<string>446084FE194283600093A6FA</string>
-				<string>446084FF194283600093A6FA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Views</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4460854C19429A520093A6FA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ALPlaceholderTextViewTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.objc</string>
-		</dict>
-		<key>4460854D19429A520093A6FA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4460854C19429A520093A6FA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4460854E19429FCE0093A6FA</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>448FA0C4194639EF00F79989</string>
-				<string>4460854C19429A520093A6FA</string>
-				<string>448D9DFA1946801D00453E69</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Cases</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4460854F19429FD40093A6FA</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>44FC5CED19463C43004812F4</string>
-				<string>44FC5CEE19463C43004812F4</string>
-				<string>42613CED1A09AFCB00CAEDBB</string>
-				<string>42613CEE1A09AFCB00CAEDBB</string>
-				<string>4460855019429FEA0093A6FA</string>
-				<string>4460855119429FEA0093A6FA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Classes</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4460855019429FEA0093A6FA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Test_ALPlaceholderTextView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4460855119429FEA0093A6FA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Test_ALPlaceholderTextView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4460855219429FEA0093A6FA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4460855119429FEA0093A6FA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>447BD44119413B840062487D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>447BD44F19413B840062487D</string>
-				<string>447BD46319413B840062487D</string>
-				<string>447BD44C19413B840062487D</string>
-				<string>447BD44B19413B840062487D</string>
-				<string>4DE5F4F0AF09DE466948CCA8</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>447BD44219413B840062487D</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>CLASSPREFIX</key>
-				<string>AL</string>
-				<key>LastUpgradeCheck</key>
-				<string>0510</string>
-				<key>ORGANIZATIONNAME</key>
-				<string></string>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>447BD44519413B840062487D</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>447BD44119413B840062487D</string>
-			<key>productRefGroup</key>
-			<string>447BD44B19413B840062487D</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>447BD44919413B840062487D</string>
-				<string>447BD45919413B840062487D</string>
-			</array>
-		</dict>
-		<key>447BD44519413B840062487D</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>447BD46B19413B840062487D</string>
-				<string>447BD46C19413B840062487D</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>447BD44619413B840062487D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>446084F9194282310093A6FA</string>
-				<string>44608500194283600093A6FA</string>
-				<string>44FC5CF21946581C004812F4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>447BD44719413B840062487D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>447BD44819413B840062487D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>dstPath</key>
-			<string>include/$(PRODUCT_NAME)</string>
-			<key>dstSubfolderSpec</key>
-			<string>16</string>
-			<key>files</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXCopyFilesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>447BD44919413B840062487D</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>447BD46D19413B840062487D</string>
-			<key>buildPhases</key>
-			<array>
-				<string>447BD44619413B840062487D</string>
-				<string>447BD44719413B840062487D</string>
-				<string>447BD44819413B840062487D</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>AutoLayoutTextViews</string>
-			<key>productName</key>
-			<string>AOTextViews</string>
-			<key>productReference</key>
-			<string>447BD44A19413B840062487D</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>447BD44A19413B840062487D</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libAutoLayoutTextViews.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>447BD44B19413B840062487D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>447BD44A19413B840062487D</string>
-				<string>447BD45A19413B840062487D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>447BD44C19413B840062487D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>447BD44D19413B840062487D</string>
-				<string>447BD45B19413B840062487D</string>
-				<string>447BD45E19413B840062487D</string>
-				<string>5A67EE64DD2D40EBBB06338F</string>
-				<string>487F164A8F7D4EEEA6DBA088</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>447BD44D19413B840062487D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>447BD44F19413B840062487D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>448D9DF3194671C700453E69</string>
-				<string>44608502194283AC0093A6FA</string>
-				<string>447BD45019413B840062487D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>AutoLayoutTextViews</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>447BD45019413B840062487D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>447BD45119413B840062487D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>447BD45119413B840062487D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AutoLayoutTextViews-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>447BD45619413B840062487D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>4460854D19429A520093A6FA</string>
-				<string>4460855219429FEA0093A6FA</string>
-				<string>42613CEF1A09AFCB00CAEDBB</string>
-				<string>449026B4197325DA00A737C3</string>
-				<string>449026B519732E9700A737C3</string>
-				<string>44FC5CEF19463C43004812F4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>447BD45719413B840062487D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>44A095891970F153000ED5B6</string>
-				<string>447BD45C19413B840062487D</string>
-				<string>0154CB6408E142EDBF9F6F69</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>447BD45819413B840062487D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>447BD46819413B840062487D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>447BD45919413B840062487D</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>447BD47019413B840062487D</string>
-			<key>buildPhases</key>
-			<array>
-				<string>7187785AB32A4D1A8D893AA5</string>
-				<string>447BD45619413B840062487D</string>
-				<string>447BD45719413B840062487D</string>
-				<string>447BD45819413B840062487D</string>
-				<string>3D0B36F7E6184547AF32BA2F</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>447BD46119413B840062487D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>AutoLayoutTextViewsTests</string>
-			<key>productName</key>
-			<string>AOTextViewsTests</string>
-			<key>productReference</key>
-			<string>447BD45A19413B840062487D</string>
-			<key>productType</key>
-			<string>com.apple.product-type.bundle.unit-test</string>
-		</dict>
-		<key>447BD45A19413B840062487D</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.cfbundle</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>AutoLayoutTextViewsTests.xctest</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>447BD45B19413B840062487D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>XCTest.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/XCTest.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>447BD45C19413B840062487D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>447BD45B19413B840062487D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>447BD45E19413B840062487D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>447BD46019413B840062487D</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>447BD44219413B840062487D</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>447BD44919413B840062487D</string>
-			<key>remoteInfo</key>
-			<string>AOTextViews</string>
-		</dict>
-		<key>447BD46119413B840062487D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>target</key>
-			<string>447BD44919413B840062487D</string>
-			<key>targetProxy</key>
-			<string>447BD46019413B840062487D</string>
-		</dict>
-		<key>447BD46319413B840062487D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>4460854E19429FCE0093A6FA</string>
-				<string>4460854F19429FD40093A6FA</string>
-				<string>447BD46419413B840062487D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>AutoLayoutTextViewsTests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>447BD46419413B840062487D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>447BD46519413B840062487D</string>
-				<string>447BD46619413B840062487D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>447BD46519413B840062487D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>AutoLayoutTextViewsTests-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>447BD46619413B840062487D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>447BD46719413B840062487D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>447BD46719413B840062487D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>447BD46819413B840062487D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>447BD46619413B840062487D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>447BD46B19413B840062487D</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>447BD46C19413B840062487D</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.1</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>447BD46D19413B840062487D</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>447BD46E19413B840062487D</string>
-				<string>447BD46F19413B840062487D</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>447BD46E19413B840062487D</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>DSTROOT</key>
-				<string>/tmp/AutoLayoutTextViews.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>AutoLayoutTextViews/AutoLayoutTextViews-Prefix.pch</string>
-				<key>OTHER_LDFLAGS</key>
-				<string>-ObjC</string>
-				<key>PRODUCT_NAME</key>
-				<string>AutoLayoutTextViews</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>447BD46F19413B840062487D</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>DSTROOT</key>
-				<string>/tmp/AutoLayoutTextViews.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>AutoLayoutTextViews/AutoLayoutTextViews-Prefix.pch</string>
-				<key>OTHER_LDFLAGS</key>
-				<string>-ObjC</string>
-				<key>PRODUCT_NAME</key>
-				<string>AutoLayoutTextViews</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>447BD47019413B840062487D</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>447BD47119413B840062487D</string>
-				<string>447BD47219413B840062487D</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>447BD47119413B840062487D</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>C00AAB0725FD6ABBB55E5C19</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>AutoLayoutTextViews/AutoLayoutTextViews-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>INFOPLIST_FILE</key>
-				<string>AutoLayoutTextViewsTests/AutoLayoutTextViewsTests-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>AutoLayoutTextViewsTests</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>447BD47219413B840062487D</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>015C12BBC346E6EC48E4175F</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>AutoLayoutTextViews/AutoLayoutTextViews-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>AutoLayoutTextViewsTests/AutoLayoutTextViewsTests-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>AutoLayoutTextViewsTests</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>448D9DF3194671C700453E69</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AutoLayoutTextViews.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>448D9DFA1946801D00453E69</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ALKeyboardAvoidingTextViewTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>448FA0C4194639EF00F79989</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>ALAutoResizingTextViewTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.objc</string>
-		</dict>
-		<key>449026B4197325DA00A737C3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>448D9DFA1946801D00453E69</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>449026B519732E9700A737C3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>448FA0C4194639EF00F79989</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>44A095891970F153000ED5B6</key>
-		<dict>
-			<key>fileRef</key>
-			<string>447BD44A19413B840062487D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>44FC5CED19463C43004812F4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Test_ALAutoResizingTextView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>44FC5CEE19463C43004812F4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>lineEnding</key>
-			<string>0</string>
-			<key>path</key>
-			<string>Test_ALAutoResizingTextView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.objc</string>
-		</dict>
-		<key>44FC5CEF19463C43004812F4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>44FC5CEE19463C43004812F4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>44FC5CF01946581C004812F4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ALKeyboardAvoidingTextView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>44FC5CF11946581C004812F4</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ALKeyboardAvoidingTextView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>44FC5CF21946581C004812F4</key>
-		<dict>
-			<key>fileRef</key>
-			<string>44FC5CF11946581C004812F4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>487F164A8F7D4EEEA6DBA088</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-AutoLayoutTextViewsTests.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>4DE5F4F0AF09DE466948CCA8</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>C00AAB0725FD6ABBB55E5C19</string>
-				<string>015C12BBC346E6EC48E4175F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5A67EE64DD2D40EBBB06338F</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-AOTextViewsTests.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>7187785AB32A4D1A8D893AA5</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>C00AAB0725FD6ABBB55E5C19</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-AutoLayoutTextViewsTests.debug.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods-AutoLayoutTextViewsTests/Pods-AutoLayoutTextViewsTests.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>447BD44219413B840062487D</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		42613CEF1A09AFCB00CAEDBB /* Test_ALKeyboardAvoidingTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 42613CEE1A09AFCB00CAEDBB /* Test_ALKeyboardAvoidingTextView.m */; };
+		446084F9194282310093A6FA /* ALAutoResizingTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 446084F8194282310093A6FA /* ALAutoResizingTextView.m */; };
+		44608500194283600093A6FA /* ALPlaceholderTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 446084FF194283600093A6FA /* ALPlaceholderTextView.m */; };
+		4460854D19429A520093A6FA /* ALPlaceholderTextViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4460854C19429A520093A6FA /* ALPlaceholderTextViewTests.m */; };
+		4460855219429FEA0093A6FA /* Test_ALPlaceholderTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4460855119429FEA0093A6FA /* Test_ALPlaceholderTextView.m */; };
+		447BD45C19413B840062487D /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 447BD45B19413B840062487D /* XCTest.framework */; };
+		447BD46819413B840062487D /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 447BD46619413B840062487D /* InfoPlist.strings */; };
+		449026B4197325DA00A737C3 /* ALKeyboardAvoidingTextViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 448D9DFA1946801D00453E69 /* ALKeyboardAvoidingTextViewTests.m */; };
+		449026B519732E9700A737C3 /* ALAutoResizingTextViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 448FA0C4194639EF00F79989 /* ALAutoResizingTextViewTests.m */; };
+		44A095891970F153000ED5B6 /* libAutoLayoutTextViews.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 447BD44A19413B840062487D /* libAutoLayoutTextViews.a */; };
+		44FC5CEF19463C43004812F4 /* Test_ALAutoResizingTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 44FC5CEE19463C43004812F4 /* Test_ALAutoResizingTextView.m */; };
+		44FC5CF21946581C004812F4 /* ALKeyboardAvoidingTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 44FC5CF11946581C004812F4 /* ALKeyboardAvoidingTextView.m */; };
+		6ED50CC8621BA8FF1C19C608 /* libPods-AutoLayoutTextViews.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E69A689147E6C81B73117F10 /* libPods-AutoLayoutTextViews.a */; };
+		D92251557C643F2B201080E7 /* libPods-AutoLayoutTextViewsTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D76956A698BDE9F9880C3A7D /* libPods-AutoLayoutTextViewsTests.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		447BD46019413B840062487D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 447BD44219413B840062487D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 447BD44919413B840062487D;
+			remoteInfo = AOTextViews;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		447BD44819413B840062487D /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		3C97E920332596DBD4729856 /* Pods-AutoLayoutTextViews.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutoLayoutTextViews.release.xcconfig"; path = "Pods/Target Support Files/Pods-AutoLayoutTextViews/Pods-AutoLayoutTextViews.release.xcconfig"; sourceTree = "<group>"; };
+		42613CED1A09AFCB00CAEDBB /* Test_ALKeyboardAvoidingTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Test_ALKeyboardAvoidingTextView.h; sourceTree = "<group>"; };
+		42613CEE1A09AFCB00CAEDBB /* Test_ALKeyboardAvoidingTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Test_ALKeyboardAvoidingTextView.m; sourceTree = "<group>"; };
+		446084F7194282310093A6FA /* ALAutoResizingTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ALAutoResizingTextView.h; sourceTree = "<group>"; };
+		446084F8194282310093A6FA /* ALAutoResizingTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ALAutoResizingTextView.m; sourceTree = "<group>"; };
+		446084FE194283600093A6FA /* ALPlaceholderTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = ALPlaceholderTextView.h; sourceTree = "<group>"; };
+		446084FF194283600093A6FA /* ALPlaceholderTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ALPlaceholderTextView.m; sourceTree = "<group>"; };
+		4460854C19429A520093A6FA /* ALPlaceholderTextViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ALPlaceholderTextViewTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		4460855019429FEA0093A6FA /* Test_ALPlaceholderTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Test_ALPlaceholderTextView.h; sourceTree = "<group>"; };
+		4460855119429FEA0093A6FA /* Test_ALPlaceholderTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Test_ALPlaceholderTextView.m; sourceTree = "<group>"; };
+		447BD44A19413B840062487D /* libAutoLayoutTextViews.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAutoLayoutTextViews.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		447BD44D19413B840062487D /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		447BD45119413B840062487D /* AutoLayoutTextViews-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AutoLayoutTextViews-Prefix.pch"; sourceTree = "<group>"; };
+		447BD45A19413B840062487D /* AutoLayoutTextViewsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AutoLayoutTextViewsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		447BD45B19413B840062487D /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		447BD45E19413B840062487D /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		447BD46519413B840062487D /* AutoLayoutTextViewsTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "AutoLayoutTextViewsTests-Info.plist"; sourceTree = "<group>"; };
+		447BD46719413B840062487D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		448D9DF3194671C700453E69 /* AutoLayoutTextViews.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoLayoutTextViews.h; sourceTree = "<group>"; };
+		448D9DFA1946801D00453E69 /* ALKeyboardAvoidingTextViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ALKeyboardAvoidingTextViewTests.m; sourceTree = "<group>"; };
+		448FA0C4194639EF00F79989 /* ALAutoResizingTextViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = ALAutoResizingTextViewTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		44FC5CED19463C43004812F4 /* Test_ALAutoResizingTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Test_ALAutoResizingTextView.h; sourceTree = "<group>"; };
+		44FC5CEE19463C43004812F4 /* Test_ALAutoResizingTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = Test_ALAutoResizingTextView.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		44FC5CF01946581C004812F4 /* ALKeyboardAvoidingTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ALKeyboardAvoidingTextView.h; sourceTree = "<group>"; };
+		44FC5CF11946581C004812F4 /* ALKeyboardAvoidingTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ALKeyboardAvoidingTextView.m; sourceTree = "<group>"; };
+		B90A51AFD8D34D01331B1B4C /* Pods-AutoLayoutTextViewsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutoLayoutTextViewsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AutoLayoutTextViewsTests/Pods-AutoLayoutTextViewsTests.debug.xcconfig"; sourceTree = "<group>"; };
+		D1D2A9FC6FA1EE2FCB9D6CA4 /* Pods-AutoLayoutTextViewsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutoLayoutTextViewsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AutoLayoutTextViewsTests/Pods-AutoLayoutTextViewsTests.release.xcconfig"; sourceTree = "<group>"; };
+		D76956A698BDE9F9880C3A7D /* libPods-AutoLayoutTextViewsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AutoLayoutTextViewsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E69A689147E6C81B73117F10 /* libPods-AutoLayoutTextViews.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AutoLayoutTextViews.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F709BA331C6B0ADAE8E98165 /* Pods-AutoLayoutTextViews.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutoLayoutTextViews.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AutoLayoutTextViews/Pods-AutoLayoutTextViews.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		447BD44719413B840062487D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6ED50CC8621BA8FF1C19C608 /* libPods-AutoLayoutTextViews.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		447BD45719413B840062487D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44A095891970F153000ED5B6 /* libAutoLayoutTextViews.a in Frameworks */,
+				447BD45C19413B840062487D /* XCTest.framework in Frameworks */,
+				D92251557C643F2B201080E7 /* libPods-AutoLayoutTextViewsTests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		44608502194283AC0093A6FA /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				446084F7194282310093A6FA /* ALAutoResizingTextView.h */,
+				446084F8194282310093A6FA /* ALAutoResizingTextView.m */,
+				44FC5CF01946581C004812F4 /* ALKeyboardAvoidingTextView.h */,
+				44FC5CF11946581C004812F4 /* ALKeyboardAvoidingTextView.m */,
+				446084FE194283600093A6FA /* ALPlaceholderTextView.h */,
+				446084FF194283600093A6FA /* ALPlaceholderTextView.m */,
+			);
+			name = Views;
+			sourceTree = "<group>";
+		};
+		4460854E19429FCE0093A6FA /* Cases */ = {
+			isa = PBXGroup;
+			children = (
+				448FA0C4194639EF00F79989 /* ALAutoResizingTextViewTests.m */,
+				4460854C19429A520093A6FA /* ALPlaceholderTextViewTests.m */,
+				448D9DFA1946801D00453E69 /* ALKeyboardAvoidingTextViewTests.m */,
+			);
+			name = Cases;
+			sourceTree = "<group>";
+		};
+		4460854F19429FD40093A6FA /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				44FC5CED19463C43004812F4 /* Test_ALAutoResizingTextView.h */,
+				44FC5CEE19463C43004812F4 /* Test_ALAutoResizingTextView.m */,
+				42613CED1A09AFCB00CAEDBB /* Test_ALKeyboardAvoidingTextView.h */,
+				42613CEE1A09AFCB00CAEDBB /* Test_ALKeyboardAvoidingTextView.m */,
+				4460855019429FEA0093A6FA /* Test_ALPlaceholderTextView.h */,
+				4460855119429FEA0093A6FA /* Test_ALPlaceholderTextView.m */,
+			);
+			name = Classes;
+			sourceTree = "<group>";
+		};
+		447BD44119413B840062487D = {
+			isa = PBXGroup;
+			children = (
+				447BD44F19413B840062487D /* AutoLayoutTextViews */,
+				447BD46319413B840062487D /* AutoLayoutTextViewsTests */,
+				447BD44C19413B840062487D /* Frameworks */,
+				447BD44B19413B840062487D /* Products */,
+				7F3FDEA9E08B7C5B59C4421E /* Pods */,
+			);
+			sourceTree = "<group>";
+		};
+		447BD44B19413B840062487D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				447BD44A19413B840062487D /* libAutoLayoutTextViews.a */,
+				447BD45A19413B840062487D /* AutoLayoutTextViewsTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		447BD44C19413B840062487D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				447BD44D19413B840062487D /* Foundation.framework */,
+				447BD45B19413B840062487D /* XCTest.framework */,
+				447BD45E19413B840062487D /* UIKit.framework */,
+				E69A689147E6C81B73117F10 /* libPods-AutoLayoutTextViews.a */,
+				D76956A698BDE9F9880C3A7D /* libPods-AutoLayoutTextViewsTests.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		447BD44F19413B840062487D /* AutoLayoutTextViews */ = {
+			isa = PBXGroup;
+			children = (
+				448D9DF3194671C700453E69 /* AutoLayoutTextViews.h */,
+				44608502194283AC0093A6FA /* Views */,
+				447BD45019413B840062487D /* Supporting Files */,
+			);
+			path = AutoLayoutTextViews;
+			sourceTree = "<group>";
+		};
+		447BD45019413B840062487D /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				447BD45119413B840062487D /* AutoLayoutTextViews-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		447BD46319413B840062487D /* AutoLayoutTextViewsTests */ = {
+			isa = PBXGroup;
+			children = (
+				4460854E19429FCE0093A6FA /* Cases */,
+				4460854F19429FD40093A6FA /* Classes */,
+				447BD46419413B840062487D /* Supporting Files */,
+			);
+			path = AutoLayoutTextViewsTests;
+			sourceTree = "<group>";
+		};
+		447BD46419413B840062487D /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				447BD46519413B840062487D /* AutoLayoutTextViewsTests-Info.plist */,
+				447BD46619413B840062487D /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		7F3FDEA9E08B7C5B59C4421E /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				F709BA331C6B0ADAE8E98165 /* Pods-AutoLayoutTextViews.debug.xcconfig */,
+				3C97E920332596DBD4729856 /* Pods-AutoLayoutTextViews.release.xcconfig */,
+				B90A51AFD8D34D01331B1B4C /* Pods-AutoLayoutTextViewsTests.debug.xcconfig */,
+				D1D2A9FC6FA1EE2FCB9D6CA4 /* Pods-AutoLayoutTextViewsTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		447BD44919413B840062487D /* AutoLayoutTextViews */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 447BD46D19413B840062487D /* Build configuration list for PBXNativeTarget "AutoLayoutTextViews" */;
+			buildPhases = (
+				0A8DE686AB7C5D1C10615584 /* 📦 Check Pods Manifest.lock */,
+				447BD44619413B840062487D /* Sources */,
+				447BD44719413B840062487D /* Frameworks */,
+				447BD44819413B840062487D /* CopyFiles */,
+				DF5E9AB8F4F64E84FD40E6FA /* 📦 Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AutoLayoutTextViews;
+			productName = AOTextViews;
+			productReference = 447BD44A19413B840062487D /* libAutoLayoutTextViews.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		447BD45919413B840062487D /* AutoLayoutTextViewsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 447BD47019413B840062487D /* Build configuration list for PBXNativeTarget "AutoLayoutTextViewsTests" */;
+			buildPhases = (
+				05BA7F88660374D9CE33FF7C /* 📦 Check Pods Manifest.lock */,
+				447BD45619413B840062487D /* Sources */,
+				447BD45719413B840062487D /* Frameworks */,
+				447BD45819413B840062487D /* Resources */,
+				C7270F5A23C5C508F495F0C7 /* 📦 Embed Pods Frameworks */,
+				48F7E2847664EC8FFB336E64 /* 📦 Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				447BD46119413B840062487D /* PBXTargetDependency */,
+			);
+			name = AutoLayoutTextViewsTests;
+			productName = AOTextViewsTests;
+			productReference = 447BD45A19413B840062487D /* AutoLayoutTextViewsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		447BD44219413B840062487D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				CLASSPREFIX = AL;
+				LastUpgradeCheck = 0510;
+				ORGANIZATIONNAME = "";
+			};
+			buildConfigurationList = 447BD44519413B840062487D /* Build configuration list for PBXProject "AutoLayoutTextViews" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 447BD44119413B840062487D;
+			productRefGroup = 447BD44B19413B840062487D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				447BD44919413B840062487D /* AutoLayoutTextViews */,
+				447BD45919413B840062487D /* AutoLayoutTextViewsTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		447BD45819413B840062487D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				447BD46819413B840062487D /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		05BA7F88660374D9CE33FF7C /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		0A8DE686AB7C5D1C10615584 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		48F7E2847664EC8FFB336E64 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AutoLayoutTextViewsTests/Pods-AutoLayoutTextViewsTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C7270F5A23C5C508F495F0C7 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AutoLayoutTextViewsTests/Pods-AutoLayoutTextViewsTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DF5E9AB8F4F64E84FD40E6FA /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AutoLayoutTextViews/Pods-AutoLayoutTextViews-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		447BD44619413B840062487D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				446084F9194282310093A6FA /* ALAutoResizingTextView.m in Sources */,
+				44608500194283600093A6FA /* ALPlaceholderTextView.m in Sources */,
+				44FC5CF21946581C004812F4 /* ALKeyboardAvoidingTextView.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		447BD45619413B840062487D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4460854D19429A520093A6FA /* ALPlaceholderTextViewTests.m in Sources */,
+				4460855219429FEA0093A6FA /* Test_ALPlaceholderTextView.m in Sources */,
+				42613CEF1A09AFCB00CAEDBB /* Test_ALKeyboardAvoidingTextView.m in Sources */,
+				449026B4197325DA00A737C3 /* ALKeyboardAvoidingTextViewTests.m in Sources */,
+				449026B519732E9700A737C3 /* ALAutoResizingTextViewTests.m in Sources */,
+				44FC5CEF19463C43004812F4 /* Test_ALAutoResizingTextView.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		447BD46119413B840062487D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 447BD44919413B840062487D /* AutoLayoutTextViews */;
+			targetProxy = 447BD46019413B840062487D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		447BD46619413B840062487D /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				447BD46719413B840062487D /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		447BD46B19413B840062487D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		447BD46C19413B840062487D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		447BD46E19413B840062487D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F709BA331C6B0ADAE8E98165 /* Pods-AutoLayoutTextViews.debug.xcconfig */;
+			buildSettings = {
+				DSTROOT = /tmp/AutoLayoutTextViews.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AutoLayoutTextViews/AutoLayoutTextViews-Prefix.pch";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = AutoLayoutTextViews;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		447BD46F19413B840062487D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3C97E920332596DBD4729856 /* Pods-AutoLayoutTextViews.release.xcconfig */;
+			buildSettings = {
+				DSTROOT = /tmp/AutoLayoutTextViews.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AutoLayoutTextViews/AutoLayoutTextViews-Prefix.pch";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = AutoLayoutTextViews;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		447BD47119413B840062487D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B90A51AFD8D34D01331B1B4C /* Pods-AutoLayoutTextViewsTests.debug.xcconfig */;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AutoLayoutTextViews/AutoLayoutTextViews-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "AutoLayoutTextViewsTests/AutoLayoutTextViewsTests-Info.plist";
+				PRODUCT_NAME = AutoLayoutTextViewsTests;
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		447BD47219413B840062487D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D1D2A9FC6FA1EE2FCB9D6CA4 /* Pods-AutoLayoutTextViewsTests.release.xcconfig */;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AutoLayoutTextViews/AutoLayoutTextViews-Prefix.pch";
+				INFOPLIST_FILE = "AutoLayoutTextViewsTests/AutoLayoutTextViewsTests-Info.plist";
+				PRODUCT_NAME = AutoLayoutTextViewsTests;
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		447BD44519413B840062487D /* Build configuration list for PBXProject "AutoLayoutTextViews" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				447BD46B19413B840062487D /* Debug */,
+				447BD46C19413B840062487D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		447BD46D19413B840062487D /* Build configuration list for PBXNativeTarget "AutoLayoutTextViews" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				447BD46E19413B840062487D /* Debug */,
+				447BD46F19413B840062487D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		447BD47019413B840062487D /* Build configuration list for PBXNativeTarget "AutoLayoutTextViewsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				447BD47119413B840062487D /* Debug */,
+				447BD47219413B840062487D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 447BD44219413B840062487D /* Project object */;
+}

--- a/AutoLayoutTextViews/ALPlaceholderTextView.m
+++ b/AutoLayoutTextViews/ALPlaceholderTextView.m
@@ -54,7 +54,7 @@
 - (void)commonInit
 {
   _placeholderColor = [UIColor lightGrayColor];
-  _placeholderInsets = UIEdgeInsetsMake(8.0f, 4.0f, 0.0f, 0.0f);
+  _placeholderInsets = UIEdgeInsetsMake(8.0f, 4.0f, 8.0f, 0.0f);
   self.font = self.font ?: [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
   
   [self startObservingNotifications];

--- a/AutoLayoutTextViews/ALPlaceholderTextView.m
+++ b/AutoLayoutTextViews/ALPlaceholderTextView.m
@@ -107,6 +107,7 @@
   [self setNeedsDisplay];
 }
 
+
 #pragma mark - Custom Accessors
 
 - (void)setPlaceholder:(NSString *)placeholder
@@ -138,6 +139,34 @@
   [self setNeedsDisplay];
 }
 
+#pragma mark - Size That Fits
+
+- (CGSize)sizeThatFits:(CGSize)size
+{
+  CGSize contentSize = [super sizeThatFits:size];
+  CGSize placeholderTextSize = [_placeholder boundingRectWithSize:CGSizeMake(size.width, CGFLOAT_MAX)
+                                                          options:NSStringDrawingUsesLineFragmentOrigin
+                                                       attributes:[self placeholderAttributes]
+                                                          context:nil].size;
+  
+  CGSize placeholderSize = CGSizeMake(placeholderTextSize.width, placeholderTextSize.height +
+                                      _placeholderInsets.top +
+                                      _placeholderInsets.bottom);
+  
+  return contentSize.height >= placeholderSize.height ? contentSize : placeholderSize;
+}
+
+- (NSDictionary *)placeholderAttributes
+{
+  NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle defaultParagraphStyle] mutableCopy];
+  paragraphStyle.lineBreakMode = NSLineBreakByWordWrapping;
+  paragraphStyle.alignment = self.textAlignment;
+  
+  return @{NSFontAttributeName: self.font,
+           NSParagraphStyleAttributeName: paragraphStyle,
+           NSForegroundColorAttributeName: self.placeholderColor};
+}
+
 #pragma mark - Draw Rect
 
 - (void)drawRect:(CGRect)rect
@@ -148,15 +177,7 @@
     return;
   }
   
-  NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle defaultParagraphStyle] mutableCopy];
-  paragraphStyle.lineBreakMode = NSLineBreakByWordWrapping;
-  paragraphStyle.alignment = self.textAlignment;
-  
-  NSDictionary *attributes = @{NSFontAttributeName: self.font,
-                               NSParagraphStyleAttributeName: paragraphStyle,
-                               NSForegroundColorAttributeName: self.placeholderColor};
-  
-  [self.placeholder drawInRect:[self calculatePlaceholderRectInsetInRect:rect] withAttributes:attributes];
+  [self.placeholder drawInRect:[self calculatePlaceholderRectInsetInRect:rect] withAttributes:[self placeholderAttributes]];
 }
 
 - (BOOL)shouldDrawPlaceholder

--- a/AutoLayoutTextViewsDemo/AutoLayoutTextViewsDemo.xcodeproj/project.pbxproj
+++ b/AutoLayoutTextViewsDemo/AutoLayoutTextViewsDemo.xcodeproj/project.pbxproj
@@ -147,11 +147,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4460853E194286690093A6FA /* Build configuration list for PBXNativeTarget "AutoLayoutTextViewsDemo" */;
 			buildPhases = (
-				48AC5D1F2B7C490899E425E0 /* Check Pods Manifest.lock */,
+				48AC5D1F2B7C490899E425E0 /* 📦 Check Pods Manifest.lock */,
 				44608508194286690093A6FA /* Sources */,
 				44608509194286690093A6FA /* Frameworks */,
 				4460850A194286690093A6FA /* Resources */,
-				FB9D0AA459E34F9F8F778979 /* Copy Pods Resources */,
+				FB9D0AA459E34F9F8F778979 /* 📦 Copy Pods Resources */,
+				39008B6E526BA84E9FB17D67 /* 📦 Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -204,14 +205,29 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		48AC5D1F2B7C490899E425E0 /* Check Pods Manifest.lock */ = {
+		39008B6E526BA84E9FB17D67 /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-AutoLayoutTextViewsDemo/Pods-AutoLayoutTextViewsDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		48AC5D1F2B7C490899E425E0 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -219,14 +235,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		FB9D0AA459E34F9F8F778979 /* Copy Pods Resources */ = {
+		FB9D0AA459E34F9F8F778979 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AutoLayoutTextViewsTests/ALPlaceholderTextViewTests.m
+++ b/AutoLayoutTextViewsTests/ALPlaceholderTextViewTests.m
@@ -101,7 +101,7 @@
 - (void)test_placeholderInsetsSetToCorrectDefaultValue
 {
   // given
-  UIEdgeInsets expected = UIEdgeInsetsMake(8.0f, 4.0f, 0.0f, 0.0f);
+  UIEdgeInsets expected = UIEdgeInsetsMake(8.0f, 4.0f, 8.0f, 0.0f);
   
   // when
   UIEdgeInsets actual = sut.placeholderInsets;

--- a/AutoLayoutTextViewsTests/ALPlaceholderTextViewTests.m
+++ b/AutoLayoutTextViewsTests/ALPlaceholderTextViewTests.m
@@ -178,6 +178,18 @@
   expect(sut.called_setNeedsDisplay).to.beTruthy();
 }
 
+- (void)test__sizeThatFits__givenLongerPlaceholderTextThanContentText_returnsSizeWithHeightFittingPlaceholder
+{
+  // given
+  sut.placeholder = @"Long Placeholder Text Long Placeholder Text Long Placeholder Text Long Placeholder Text Long Placeholder Text Long Placeholder Text";
+  
+  // when
+  CGSize actual = [sut sizeThatFits:CGSizeMake(50.0f, 50.0f)];
+  
+  // then
+  expect(actual.height).to.beGreaterThan(50.0f);
+}
+
 - (void)test___drawRect___returnsNO_ifHasText
 {
   // given

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AutoLayoutTextViews (1.2.1)
+  - AutoLayoutTextViews (1.2.3)
   - Expecta (1.0.0)
   - OCMock (3.1.2)
 
@@ -10,11 +10,13 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   AutoLayoutTextViews:
-    :path: .
+    :path: "."
 
 SPEC CHECKSUMS:
-  AutoLayoutTextViews: 48faabcd0e2270f789ed027a79ab253184fa6e2e
+  AutoLayoutTextViews: 50d76d8938f263794e3344ee6876001f806c7cda
   Expecta: 32604574add2c46a36f8d2f716b6c5736eb75024
   OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
 
-COCOAPODS: 0.36.4
+PODFILE CHECKSUM: 39fc9cc36b90223b88dacabd7f23e46884ff2383
+
+COCOAPODS: 1.0.0.beta.6


### PR DESCRIPTION
`ALPlaceholderTextView` will now account for placeholder text when calculating 'sizeThatFits`.

Previously, when the placeholder text was longer than the text in the text view, the view height would size only for the content text.

This primarialy affects the functionality of 'ALAutoresizingTextView`.